### PR TITLE
Enable Hardened Malloc on Haiku with arc4random_buf support

### DIFF
--- a/build-bench-env.sh
+++ b/build-bench-env.sh
@@ -518,7 +518,7 @@ if test "$haiku" = "1"; then
   setup_fg=0
   setup_gd=0
   setup_hd=0
-  setup_hm=0
+  # setup_hm=0
   setup_lt=0
   setup_sm=0
   setup_scudo=0
@@ -534,6 +534,9 @@ fi
 
 if test "$setup_hm" = "1"; then
   checkout hm $version_hm https://github.com/GrapheneOS/hardened_malloc
+  if test "$haiku" = "1"; then
+    patch -p1 < ../../patches/hardened_malloc_haiku.patch
+  fi
   make CONFIG_NATIVE=true CONFIG_WERROR=false VARIANT=light -j $proc
   make CONFIG_NATIVE=true CONFIG_WERROR=false VARIANT=default -j $proc
   popd

--- a/patches/hardened_malloc_haiku.patch
+++ b/patches/hardened_malloc_haiku.patch
@@ -1,0 +1,37 @@
+diff --git a/util.c b/util.c
+index a8e51b3..13b631d 100644
+--- a/util.c
++++ b/util.c
+@@ -1,6 +1,9 @@
+ #include <errno.h>
+ #include <fcntl.h>
+ #include <string.h>
++#ifdef __HAIKU__
++#include <stdlib.h>
++#endif
+ #include <sys/mman.h>
+ #include <sys/random.h>
+ #include <sys/stat.h>
+@@ -49,6 +52,9 @@ void get_random(void *buffer, size_t size) {
+         }
+     }
+
++#elif defined(__HAIKU__)
++    arc4random_buf(buffer, size);
++    return;
+ #else
+     while (true) {
+         ssize_t ret = getrandom(buffer, size, 0);
+diff --git a/util.h b/util.h
+index 9235d97..b2a0c64 100644
+--- a/util.h
++++ b/util.h
+@@ -4,6 +4,9 @@
+ #include <stdbool.h>
+ #include <stddef.h>
+ #include <sys/mman.h>
++#ifdef __HAIKU__
++#define MAP_FIXED_NOREPLACE 0
++#endif
+
+ #include "h_malloc/config.h"


### PR DESCRIPTION
Enabled the Hardened Malloc (`hm`) build on Haiku in `build-bench-env.sh`. Added `patches/hardened_malloc_haiku.patch` to replace Linux-specific `getrandom()` with `arc4random_buf()` and handle missing `MAP_FIXED_NOREPLACE` flag. This addresses the user request to "bring back hm" and utilize Haiku's randomness API.