### PR TITLE
Fix Haiku package name for Clang

### DIFF
--- a/build-bench-env.sh
+++ b/build-bench-env.sh
@@ -489,9 +489,9 @@ if test "$setup_packages" = "1"; then
     # gnu_sed    -- GNU sed, needed for -E and -i.bak in bench.sh result parsing
     # dos2unix   -- needed to patch shbench source files
     echo ""
-    echo "> pkgman install -y gcc clang cmake ninja python3 automake libtool autoconf git wget dos2unix bc gmp_devel gnu_sed coreutils ruby libatomic_ops_devel time snappy_devel readline_devel"
+    echo "> pkgman install -y gcc llvm12_clang cmake ninja python3 automake libtool autoconf git wget dos2unix bc gmp_devel gnu_sed coreutils ruby libatomic_ops_devel time snappy_devel readline_devel"
     echo ""
-    pkgman install -y gcc clang cmake ninja python3 automake libtool autoconf \
+    pkgman install -y gcc llvm12_clang cmake ninja python3 automake libtool autoconf \
       git wget dos2unix bc gmp_devel gnu_sed coreutils \
       ruby libatomic_ops_devel time \
       snappy_devel readline_devel


### PR DESCRIPTION
Replaced `clang` with `llvm12_clang` in `build-bench-env.sh` package installation list for Haiku, as the generic `clang` package is not available in the repositories. This fixes the package installation failure reported by the user.