### PR TITLE
Update Hardened Malloc patch for Haiku

### DIFF
--- a/patches/hardened_malloc_haiku.patch
+++ b/patches/hardened_malloc_haiku.patch
@@ -1,37 +1,35 @@
-diff --git a/util.c b/util.c
-index a8e51b3..13b631d 100644
---- a/util.c
-+++ b/util.c
-@@ -1,6 +1,9 @@
+diff --git a/random.c b/random.c
+index 8883531..abda53e 100644
+--- a/random.c
++++ b/random.c
+@@ -1,13 +1,20 @@
  #include <errno.h>
- #include <fcntl.h>
  #include <string.h>
+
 +#ifdef __HAIKU__
 +#include <stdlib.h>
++#else
++#include <sys/random.h>
 +#endif
- #include <sys/mman.h>
- #include <sys/random.h>
- #include <sys/stat.h>
-@@ -49,6 +52,9 @@ void get_random(void *buffer, size_t size) {
-         }
-     }
++
+ #include "chacha.h"
+ #include "random.h"
+ #include "util.h"
 
-+#elif defined(__HAIKU__)
-+    arc4random_buf(buffer, size);
-+    return;
- #else
-     while (true) {
-         ssize_t ret = getrandom(buffer, size, 0);
-diff --git a/util.h b/util.h
-index 9235d97..b2a0c64 100644
---- a/util.h
-+++ b/util.h
-@@ -4,6 +4,9 @@
- #include <stdbool.h>
- #include <stddef.h>
- #include <sys/mman.h>
+-#include <sys/random.h>
+-
+ static void get_random_seed(void *buf, size_t size) {
 +#ifdef __HAIKU__
-+#define MAP_FIXED_NOREPLACE 0
-+#endif
++    arc4random_buf(buf, size);
++#else
+     while (size) {
+         ssize_t r;
 
- #include "h_malloc/config.h"
+@@ -22,6 +29,7 @@ static void get_random_seed(void *buf, size_t size) {
+         buf = (char *)buf + r;
+         size -= r;
+     }
++#endif
+ }
+
+ void random_state_init(struct random_state *state) {


### PR DESCRIPTION
Updated `patches/hardened_malloc_haiku.patch` to correctly apply to `random.c` instead of `util.c`, fixing build failures on Haiku. The patch now replaces `get_random_seed` with `arc4random_buf` for Haiku and removes outdated `MAP_FIXED_NOREPLACE` definition.

---
*PR created automatically by Jules for task [8294430961451835303](https://jules.google.com/task/8294430961451835303) started by @tonestone57*