### PR TITLE
Update Hardened Malloc patch for Haiku support (v2)

### DIFF
--- a/patches/hardened_malloc_haiku.patch
+++ b/patches/hardened_malloc_haiku.patch
@@ -1,3 +1,26 @@
+diff --git a/memory.c b/memory.c
+index 2d995ef..42dff4e 100644
+--- a/memory.c
++++ b/memory.c
+@@ -1,7 +1,9 @@
+ #include <errno.h>
+
+ #include <sys/mman.h>
++#ifndef __HAIKU__
+ #include <sys/prctl.h>
++#endif
+
+ #ifndef PR_SET_VMA
+ #define PR_SET_VMA 0x53564d41
+@@ -95,7 +97,7 @@ bool memory_purge(void *ptr, size_t size) {
+ }
+
+ bool memory_set_name(UNUSED void *ptr, UNUSED size_t size, UNUSED const char *name) {
+-#ifdef LABEL_MEMORY
++#if defined(LABEL_MEMORY) && !defined(__HAIKU__)
+     return prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, ptr, size, name);
+ #else
+     return false;
 diff --git a/random.c b/random.c
 index 8883531..abda53e 100644
 --- a/random.c


### PR DESCRIPTION
This commit updates `patches/hardened_malloc_haiku.patch` to support the version of Hardened Malloc (version 11, commit 995ce07) currently used in `build-bench-env.sh`.

- `random.c`: Replace Linux-specific `getrandom` with `arc4random_buf` on Haiku.
- `memory.c`: Guard `#include <sys/prctl.h>` and `prctl` calls with `#ifndef __HAIKU__` as Haiku does not support `prctl` or `sys/prctl.h`.
- Remove outdated patch hunks for `util.c` and `util.h` (e.g., `MAP_FIXED_NOREPLACE` is no longer used/needed in this context).