### PR TITLE
Update Hardened Malloc patch and build flags for Haiku support

### DIFF
--- a/build-bench-env.sh
+++ b/build-bench-env.sh
@@ -536,9 +536,13 @@ if test "$setup_hm" = "1"; then
   checkout hm $version_hm https://github.com/GrapheneOS/hardened_malloc
   if test "$haiku" = "1"; then
     patch -p1 < ../../patches/hardened_malloc_haiku.patch
+    export LDLIBS="-lbsd"
   fi
   make CONFIG_NATIVE=true CONFIG_WERROR=false VARIANT=light -j $proc
   make CONFIG_NATIVE=true CONFIG_WERROR=false VARIANT=default -j $proc
+  if test "$haiku" = "1"; then
+    unset LDLIBS
+  fi
   popd
 fi
 


### PR DESCRIPTION
This commit updates `patches/hardened_malloc_haiku.patch` and `build-bench-env.sh` to properly support Hardened Malloc on Haiku.

1.  `patches/hardened_malloc_haiku.patch`:
    -   Targets `random.c` instead of `util.c`: Replaces Linux-specific `getrandom` with `arc4random_buf` (available via libbsd on Haiku).
    -   Targets `memory.c`: Guards `#include <sys/prctl.h>` and `prctl` calls with `#ifndef __HAIKU__` as Haiku does not support `prctl`.
    -   Removes outdated hunks for `util.c`/`util.h`.

2.  `build-bench-env.sh`:
    -   Exports `LDLIBS="-lbsd"` when building Hardened Malloc on Haiku to resolve `arc4random_buf`.
    -   Unsets `LDLIBS` afterwards to avoid side effects.