### PR TITLE
Fix Haiku build for Hardened Malloc and IsoAlloc

### DIFF
--- a/build-bench-env.sh
+++ b/build-bench-env.sh
@@ -554,6 +554,9 @@ fi
 
 if test "$setup_iso" = "1"; then
   checkout iso $version_iso https://github.com/struct/isoalloc
+  if test "$haiku" = "1"; then
+    patch -p1 < ../../patches/iso_alloc_haiku.patch
+  fi
   make library -j $procs
   popd
 fi

--- a/patches/iso_alloc_haiku.patch
+++ b/patches/iso_alloc_haiku.patch
@@ -1,0 +1,22 @@
+diff --git a/src/iso_alloc_random.c b/src/iso_alloc_random.c
+index 408c92b..e3a50b5 100644
+--- a/src/iso_alloc_random.c
++++ b/src/iso_alloc_random.c
+@@ -15,7 +15,7 @@
+ #include <Security/SecRandom.h>
+ #elif __FreeBSD__ || __DragonFly__ || __linux__ || __ANDROID__
+ #include <sys/random.h>
+-#elif __NetBSD__
++#elif __NetBSD__ || __HAIKU__
+ #include <stdlib.h>
+ #elif __sun
+ #include <sys/random.h>
+@@ -59,7 +59,7 @@ INTERNAL_HIDDEN INLINE uint64_t rand_uint64(void) {
+     ret = SecRandomCopyBytes(kSecRandomDefault, sizeof(val), &val);
+ #elif __FreeBSD__ || __DragonFly__ || __linux__ || __ANDROID__ || __sun
+     ret = getrandom(&val, sizeof(val), GRND_NONBLOCK) != sizeof(val);
+-#elif __NetBSD__
++#elif __NetBSD__ || __HAIKU__
+     /* Temporary solution until NetBSD 10 released with getrandom support */
+     arc4random_buf(&val, sizeof(val));
+ #endif


### PR DESCRIPTION
This commit addresses build failures for `hm` (Hardened Malloc) and `iso` (IsoAlloc) on Haiku.

Hardened Malloc (`hm`):
- Updated `patches/hardened_malloc_haiku.patch` to support the current version (v11):
  - `random.c`: Replaced `getrandom` with `arc4random_buf` (via `<stdlib.h>`) on Haiku.
  - `memory.c`: Guarded `sys/prctl.h` inclusion and `prctl` calls with `#ifndef __HAIKU__`.
  - Removed outdated patch hunks for `util.c`/`util.h`.
- Updated `build-bench-env.sh`:
  - Export `LDLIBS="-lbsd"` when building `hm` on Haiku to resolve `arc4random_buf`.
  - Unset `LDLIBS` after the build.

IsoAlloc (`iso`):
- Created `patches/iso_alloc_haiku.patch`:
  - Modifies `src/iso_alloc_random.c` to include `<stdlib.h>` and use `arc4random_buf` when `__HAIKU__` is defined, fixing "unknown OS" error.
- Updated `build-bench-env.sh`:
  - Apply `patches/iso_alloc_haiku.patch` when building `iso` on Haiku.