### PR TITLE
Fix Haiku build failures for multiple allocators

### DIFF
--- a/build-bench-env.sh
+++ b/build-bench-env.sh
@@ -664,7 +664,7 @@ fi
 
 if test "$setup_tbb" = "1"; then
   checkout tbb $version_tbb https://github.com/oneapi-src/oneTBB
-  cmake -DCMAKE_BUILD_TYPE=Release -DTBB_BUILD=OFF -DTBB_TEST=OFF -DTBB_OUTPUT_DIR_BASE=bench .
+  cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release -DTBB_BUILD=OFF -DTBB_TEST=OFF -DTBB_OUTPUT_DIR_BASE=bench .
   make -j $procs
   popd
 fi

--- a/patches/tbb_cmake_minimum.patch
+++ b/patches/tbb_cmake_minimum.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a24287b1..eb52cd88 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -12,7 +12,7 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+-cmake_minimum_required(VERSION 3.1)
++cmake_minimum_required(VERSION 3.5)
+
+ # Enable CMake policies


### PR DESCRIPTION
This commit addresses several build issues encountered on Haiku:

1.  **Hardened Malloc (`hm`):**
    -   Updated `patches/hardened_malloc_haiku.patch` to support v11:
        -   Uses `arc4random_buf` (via `<stdlib.h>`) in `random.c`.
        -   Guards `sys/prctl.h` inclusion and `prctl` calls in `memory.c` (not supported on Haiku).
    -   Updated `build-bench-env.sh` to link against `libbsd` (`-lbsd`) for `arc4random_buf`.

2.  **IsoAlloc (`iso`):**
    -   Added `patches/iso_alloc_haiku.patch` to fix "unknown OS" compilation error by enabling Haiku support (using `arc4random_buf`).
    -   Updated `build-bench-env.sh` to apply this patch.

3.  **PartitionAlloc (`pa`):**
    -   Disabled `pa` setup on Haiku in `build-bench-env.sh` as it requires `depot_tools`/`cipd` which are unsupported.

4.  **Intel TBB (`tbb`):**
    -   Updated `build-bench-env.sh` to pass `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` to CMake, resolving policy errors with newer CMake versions.