### PR TITLE
Fix sh6bench/sh8bench build on Haiku and update CMake version

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 project(mimalloc-bench CXX C)
 set(CMAKE_CXX_STANDARD 17)
 

--- a/bench/shbench/sh6bench.patch
+++ b/bench/shbench/sh6bench.patch
@@ -1,5 +1,5 @@
---- sh6bench.c	2026-02-22 21:23:53.831085365 +0000
-+++ sh6bench-new.c	2026-02-22 21:24:15.103085126 +0000
+--- sh6bench.c	2026-02-22 21:39:54.759913318 +0000
++++ sh6bench-new.c	2026-02-22 21:42:55.503911283 +0000
 @@ -50,7 +50,7 @@
  #endif /* SYS_MULTI_THREAD */
 
@@ -18,17 +18,16 @@
  #define _INCLUDE_POSIX_SOURCE
  #include <sys/signal.h>
  #include <pthread.h>
-@@ -110,7 +110,8 @@
+@@ -110,7 +110,7 @@
  /* Note: the SmartHeap header files must be included _after_ any files that
   * declare malloc et al
   */
 -#include "smrtheap.h"
 +// #include "smrtheap.h"
-+
  #ifdef MALLOC_ONLY
  #undef malloc
  #undef realloc
-@@ -152,7 +153,7 @@
+@@ -152,7 +152,7 @@
  FILE *fout, *fin;
  unsigned uMaxBlockSize = 1000;
  unsigned uMinBlockSize = 1;
@@ -37,7 +36,7 @@
 
  unsigned long promptAndRead(char *msg, unsigned long defaultVal, char fmtCh);
 
-@@ -195,7 +196,16 @@
+@@ -195,7 +195,16 @@
  #endif
 
 	setbuf(stdout, NULL);  /* turn off buffering for output */
@@ -55,15 +54,16 @@
 	if (argc > 1)
 		fin = fopen(argv[1], "r");
 	else
-@@ -204,7 +214,7 @@
+@@ -203,7 +212,8 @@
+	if (argc > 2)
 		fout = fopen(argv[2], "w");
 	else
-		fout = stdout;
--
+-		fout = stdout;
++		fout = stdout;
 +#endif
+
 	ulCallCount = promptAndRead("call count", ulCallCount, 'u');
 	uMinBlockSize = (unsigned)promptAndRead("min block size",uMinBlockSize,'u');
-	uMaxBlockSize = (unsigned)promptAndRead("max block size",uMaxBlockSize,'u');
 @@ -220,7 +230,7 @@
 		ThreadID *tids;
 
@@ -132,6 +132,24 @@
 	if (arg && ((result = strtoul(arg, &err, 10)) != 0
 					|| (*err == '\n' && arg != err)))
 	{
+@@ -429,7 +451,7 @@
+							 (pthread_startroutine_t)fn, arg) == -1)
+		 return THREAD_NULL;
+
+-#elif defined(_POSIX_THREADS) || defined(_POSIX_REENTRANT_FUNCTIONS)
++#elif defined(_POSIX_THREADS) || defined(_POSIX_REENTRANT_FUNCTIONS) || defined(__HAIKU__)
+	pthread_attr_t attr;
+	pthread_attr_init(&attr);
+ #ifdef _AIX
+@@ -462,7 +484,7 @@
+	while (tidCnt--)
+		thr_join(0, NULL, NULL);
+
+-#elif defined(_POSIX_THREADS) || defined(_POSIX_REENTRANT_FUNCTIONS)
++#elif defined(_POSIX_THREADS) || defined(_POSIX_REENTRANT_FUNCTIONS) || defined(__HAIKU__)
+	while (tidCnt--)
+		pthread_join(tids[tidCnt], NULL);
+
 @@ -509,6 +531,8 @@
 	return get_nprocs();
  #elif defined(_SC_NPROCESSORS_ONLN)

--- a/bench/shbench/sh8bench.patch
+++ b/bench/shbench/sh8bench.patch
@@ -1,5 +1,5 @@
---- SH8BENCH.C	2026-02-22 21:23:53.831085365 +0000
-+++ sh8bench-new.c	2026-02-22 21:24:15.107085126 +0000
+--- SH8BENCH.C	2026-02-22 21:39:54.875913317 +0000
++++ sh8bench-new.c	2026-02-22 21:42:55.507911283 +0000
 @@ -52,7 +52,7 @@
  #endif /* SYS_MULTI_THREAD */
 
@@ -54,16 +54,17 @@
 	if (argc > 1)
 		fin = fopen(argv[1], "r");
 	else
-@@ -200,7 +209,7 @@
+@@ -199,7 +208,8 @@
+	if (argc > 2)
 		fout = fopen(argv[2], "w");
 	else
-		fout = stdout;
--
+-		fout = stdout;
++		fout = stdout;
 +	#endif
+
 	if (argc > 3)
 		ulHeapSize = atol(argv[3]);
-	else
-@@ -215,7 +224,7 @@
+@@ -215,7 +225,7 @@
 	if (argc > 5)
 		ulThreadCount = atol(argv[5]);
 	else
@@ -72,7 +73,7 @@
 
 	if (argc > 6)
 		ulForeignAllocCount = atol(argv[5]);
-@@ -240,7 +249,7 @@
+@@ -240,7 +250,7 @@
 		void *threadArg = NULL;
 
  #ifdef WIN32
@@ -81,7 +82,7 @@
 
 		if (uCPUs)
 		{
-@@ -539,11 +548,14 @@
+@@ -539,10 +549,13 @@
 
 				mp = memory;
 			}
@@ -91,13 +92,12 @@
 			{
 				printf("Out of memory\n");
 				_exit (1);
-			}
-+				char* p = mp[-1]; p[0] = 0; p[size-1] = 0;
 +			}
++				char* p = mp[-1]; p[0] = 0; p[size-1] = 0;
+			}
 		}
 	}
-
-@@ -577,6 +589,7 @@
+@@ -577,6 +590,7 @@
  {
 	char *arg = NULL, *err;
 	unsigned long result;
@@ -105,7 +105,7 @@
 	{
 		char buf[12];
 		static char fmt[] = "\n%s [%lu]: ";
-@@ -585,6 +598,7 @@
+@@ -585,6 +599,7 @@
 		if (fgets(buf, 11, fin))
 			arg = &buf[0];
 	}
@@ -113,7 +113,25 @@
 	if (arg && ((result = strtoul(arg, &err, 10)) != 0
 					|| (*err == '\n' && arg != err)))
 	{
-@@ -701,6 +715,8 @@
+@@ -619,7 +634,7 @@
+							 (pthread_startroutine_t)fn, arg) == -1)
+		 return THREAD_NULL;
+
+-#elif defined(_POSIX_THREADS) || defined(_POSIX_REENTRANT_FUNCTIONS)
++#elif defined(_POSIX_THREADS) || defined(_POSIX_REENTRANT_FUNCTIONS) || defined(__HAIKU__)
+	pthread_attr_t attr;
+	pthread_attr_init(&attr);
+ #ifdef _AIX
+@@ -654,7 +669,7 @@
+	while (tidCnt--)
+		thr_join(0, NULL, NULL);
+
+-#elif defined(_POSIX_THREADS) || defined(_POSIX_REENTRANT_FUNCTIONS)
++#elif defined(_POSIX_THREADS) || defined(_POSIX_REENTRANT_FUNCTIONS) || defined(__HAIKU__)
+	while (tidCnt--)
+		pthread_join(tids[tidCnt], NULL);
+
+@@ -701,6 +716,8 @@
 	return get_nprocs();
  #elif defined(_SC_NPROCESSORS_ONLN)
 	return sysconf(_SC_NPROCESSORS_ONLN);


### PR DESCRIPTION
This PR resolves build failures for `sh6bench` and `sh8bench` on Haiku OS. 

Changes:
1.  **Patches Updated:** `bench/shbench/sh6bench.patch` and `bench/shbench/sh8bench.patch` now correctly enable POSIX threads support on Haiku by adding `|| defined(__HAIKU__)` to the relevant `#ifdef` guards. This ensures `ThreadID` is defined and `pthread.h` is included.
2.  **CMake Update:** `bench/CMakeLists.txt` minimum version updated to 3.10 to fix deprecation warnings.

Verified by regenerating patches against fresh source downloads and confirming they apply cleanly and contain the correct preprocessor definitions.

---
*PR created automatically by Jules for task [12262982833883517130](https://jules.google.com/task/12262982833883517130) started by @tonestone57*