### PR TITLE
Fix malformed patch for TBB on Haiku

### DIFF
--- a/patches/tbb_haiku.patch
+++ b/patches/tbb_haiku.patch
@@ -29,7 +29,7 @@ diff --git a/src/tbbmalloc/tbbmalloc.cpp b/src/tbbmalloc/tbbmalloc.cpp
 index 7311107c..44d4719c 100644
 --- a/src/tbbmalloc/tbbmalloc.cpp
 +++ b/src/tbbmalloc/tbbmalloc.cpp
-@@ -43,7 +43,7 @@
+@@ -43,6 +43,6 @@
  #elif __APPLE__
  #define MALLOCLIB_NAME "libtbbmalloc" DEBUG_SUFFIX ".dylib"
 -#elif __FreeBSD__ || __NetBSD__ || __OpenBSD__ || __sun || _AIX || __ANDROID__


### PR DESCRIPTION
Corrected the line count in a hunk header within `patches/tbb_haiku.patch`. The header `@@ -43,7 +43,7 @@` was changed to `@@ -43,6 +43,6 @@` to match the actual content (6 lines of original context). This fixes the build failure when setting up the TBB benchmark environment on Haiku.

---
*PR created automatically by Jules for task [10459310317157221024](https://jules.google.com/task/10459310317157221024) started by @tonestone57*