### PR TITLE
Fix sh6bench build on Haiku

### DIFF
--- a/bench/shbench/sh6bench.patch
+++ b/bench/shbench/sh6bench.patch
@@ -1,6 +1,6 @@
 --- sh6bench.c	2026-02-23 08:15:42.330279030 +0000
 +++ sh6bench-new.c	2026-02-23 08:15:42.334279030 +0000
-@@ -50,15 +50,20 @@
+@@ -50,15 +50,24 @@
  #endif /* SYS_MULTI_THREAD */
 
  #elif defined(UNIX) || defined(__hpux) || defined(_AIX) || defined(__sun) \
@@ -21,7 +21,12 @@
 -	|| defined(__DGUX__) || defined(__linux__)
 +	|| defined(__DGUX__) || defined(__linux__) || defined(__HAIKU__)
  #define _INCLUDE_POSIX_SOURCE
- #include <sys/signal.h>
+-#include <sys/signal.h>
++#ifndef __HAIKU__
++#include <sys/signal.h>
++#else
++#include <signal.h>
++#endif
  #include <pthread.h>
 @@ -110,7 +115,7 @@
  /* Note: the SmartHeap header files must be included _after_ any files that


### PR DESCRIPTION
The `sh6bench` benchmark failed to compile on Haiku because it tried to include `<sys/signal.h>`, which does not exist on Haiku (it uses `<signal.h>`).

This change updates `bench/shbench/sh6bench.patch` to modify the include directive.
The original `sh6bench.patch` already added `|| defined(__HAIKU__)` to the platform check block (verified by inspecting the patch file content), but it did not change the `#include <sys/signal.h>` line.

I updated the patch to replace:
```c
#include <sys/signal.h>
```
with:
```c
#ifndef __HAIKU__
#include <sys/signal.h>
#else
#include <signal.h>
#endif
```

This ensures that on Haiku, `<signal.h>` is used, fixing the build error.
I also verified that `sh8bench.patch` already uses `<signal.h>`, so it does not need modification.

---
*PR created automatically by Jules for task [14275519194195003652](https://jules.google.com/task/14275519194195003652) started by @tonestone57*