### PR TITLE
Final fixes for Linux and Haiku benchmark environment

### DIFF
--- a/build-bench-env.sh
+++ b/build-bench-env.sh
@@ -676,6 +676,7 @@ fi
 
 if test "$setup_tc" = "1"; then
   checkout tc $version_tc https://github.com/gperftools/gperftools
+  patch -p0 < ../../patches/gperftools_haiku.patch
   if test -f configure; then
     echo "already configured"
   else
@@ -741,7 +742,7 @@ if test "$setup_sn" = "1"; then
     mkdir -p release
     cd release
     # CXX11_DESTRUCTORS is needed as broken on Alpine without, should be fixed in the future upstrem.
-    env CXX=clang++ cmake -G Ninja .. -DCMAKE_BUILD_TYPE=Release -DSNMALLOC_CLEANUP=CXX11_DESTRUCTORS
+    cmake -G Ninja .. -DCMAKE_BUILD_TYPE=Release -DSNMALLOC_CLEANUP=CXX11_DESTRUCTORS
     cd ..
   fi
   cd release

--- a/patches/gperftools_haiku.patch
+++ b/patches/gperftools_haiku.patch
@@ -1,0 +1,19 @@
+--- src/tests/proc_maps_iterator_test.cc
++++ src/tests/proc_maps_iterator_test.cc
+@@ -69,6 +69,16 @@
+
+ #ifdef PRINT_DL_PHDRS
+
++#ifndef PF_R
++#define PF_R 0x4
++#endif
++#ifndef PF_W
++#define PF_W 0x2
++#endif
++#ifndef PF_X
++#define PF_X 0x1
++#endif
++
+ std::string MapFlags(uintptr_t flags) {
+   std::string ret;
+   ret += (flags & PF_R) ? "r" : "-";


### PR DESCRIPTION
- Fixed `sh6bench` and `sh8bench` patches to properly handle `defaultThreadCount` scoping.
- Added `gperftools_haiku.patch` to fix missing `PF_R` etc in `gperftools`.
- Updated Haiku Python package name to `python3.14` in `build-bench-env.sh`.
- Removed hardcoded `clang++` from `snmalloc` build to avoid crashes.
- Ensured `sedcmd` is correctly used and defined in `bench.sh`.
- Removed temporary Python scripts and binary artifacts.
- Improved script portability and fixed CMake flag issues.
- Confirmed full build success on Linux for major allocators.