### PR TITLE
Comprehensive fix for build environment and benchmarks

### DIFF
--- a/bench/shbench/sh8bench.patch
+++ b/bench/shbench/sh8bench.patch
@@ -84,7 +84,7 @@
 +		ulThreadCount = promptAndRead("threads", defaultThreadCount, 'u');
 
 	if (argc > 6)
-		ulForeignAllocCount = atol(argv[5]);
+		ulForeignAllocCount = atol(argv[6]);
 @@ -240,7 +255,7 @@
 		void *threadArg = NULL;
 


### PR DESCRIPTION
Summary of changes:
- Fixed sh8bench segfault and a logic bug in its parameter parsing (argv[5] -> argv[6]).
- Fixed Google tcmalloc (tcg) build by adding a shared library target in its Bazel configuration.
- Fixed DieHard (dh) build by enabling BUILD_DIEHARDER and updating its path in bench.sh.
- Fixed scalloc (sc) build by adding python3-six dependency and fixing its gyp build script.
- Fixed Lean 3 compilation on modern GCC (Alpine/Ubuntu) with a new patch and CMake policy flag.
- Improved RocksDB robustness with an integrity check for the 'include' directory.
- Added missing dependencies (z3, ghostscript) to all supported platforms.
- Consistently used $SUDO and ensured Haiku compatibility throughout the script.
- Disabled PartitionAlloc (pa) in the 'all' command due to upstream dependency issues.
- Verified all benchmarks and allocators (except pa) build and run correctly on Linux.