### PR TITLE
Fix sh8bench build and errors on Linux and Haiku

### DIFF
--- a/bench/shbench/sh6bench.patch
+++ b/bench/shbench/sh6bench.patch
@@ -1,5 +1,5 @@
---- a/sh6bench.c	2026-02-24 12:10:48.181551335 +0000
-+++ b/sh6bench-new.c	2026-02-24 16:54:59.512940499 +0000
+--- a/sh6bench.c	2026-02-24 16:58:34.232938081 +0000
++++ b/sh6bench-new.c	2026-02-24 17:27:36.069841217 +0000
 @@ -50,17 +50,24 @@
  #endif /* SYS_MULTI_THREAD */
 
@@ -90,7 +90,7 @@
  }
 
  void doBench(void *arg)
-@@ -334,11 +356,17 @@
+@@ -334,11 +356,19 @@
 			while (iterations--)
 			{
 
@@ -103,13 +103,15 @@
 +				else
 +				{
 +					char* p = *mp;
-+					p[0] = 0; p[size-1] = 0;
++					if (size > 0) {
++						p[0] = 0; p[size-1] = 0;
++					}
 +					mp++;
 +				}
 
 	  /* while allocating skip over that portion of the buffer that still
 	     holds pointers from the previous cycle
-@@ -387,14 +415,14 @@
+@@ -387,14 +417,14 @@
  {
 	char *arg = NULL, *err;
 	unsigned long result;
@@ -125,14 +127,14 @@
 +#ifndef BENCH
 +	static char fmt[] = "\n%s [%lu]: ";
 +	fmt[7] = fmtCh;
-+	fprintf_silent(fout, fmt, msg, defaultVal);
++	fprintf(fout, fmt, msg, defaultVal);
 +	if (fgets(buf, 11, fin))
 +		arg = &buf[0];
 +#endif
 	if (arg && ((result = strtoul(arg, &err, 10)) != 0
 					|| (*err == '\n' && arg != err)))
 	{
-@@ -429,7 +457,7 @@
+@@ -429,7 +459,7 @@
 							 (pthread_startroutine_t)fn, arg) == -1)
 		 return THREAD_NULL;
 
@@ -141,7 +143,7 @@
 	pthread_attr_t attr;
 	pthread_attr_init(&attr);
  #ifdef _AIX
-@@ -462,7 +490,7 @@
+@@ -462,7 +492,7 @@
 	while (tidCnt--)
 		thr_join(0, NULL, NULL);
 

--- a/bench/shbench/sh6bench.patch
+++ b/bench/shbench/sh6bench.patch
@@ -1,5 +1,5 @@
---- sh6bench.c	2026-02-24 11:57:30.969560311 +0000
-+++ sh6bench-new.c	2026-02-24 12:09:31.737552195 +0000
+--- a/sh6bench.c	2026-02-24 12:10:48.181551335 +0000
++++ b/sh6bench-new.c	2026-02-24 16:54:59.512940499 +0000
 @@ -50,17 +50,24 @@
  #endif /* SYS_MULTI_THREAD */
 
@@ -16,7 +16,8 @@
  #include <unistd.h>
  #ifdef SYS_MULTI_THREAD
  #if defined(__hpux) || defined(__osf__) || defined(_AIX) || defined(sgi) \
-	|| defined(__DGUX__) || defined(__linux__)
+-	|| defined(__DGUX__) || defined(__linux__)
++	|| defined(__DGUX__) || defined(__linux__) || defined(__HAIKU__)
  #define _INCLUDE_POSIX_SOURCE
 +#ifndef __HAIKU__
  #include <sys/signal.h>
@@ -120,8 +121,8 @@
 -		if (fgets(buf, 11, fin))
 -			arg = &buf[0];
 -	}
-+#ifndef BENCH
 +	char buf[12];
++#ifndef BENCH
 +	static char fmt[] = "\n%s [%lu]: ";
 +	fmt[7] = fmtCh;
 +	fprintf_silent(fout, fmt, msg, defaultVal);

--- a/bench/shbench/sh6bench.patch
+++ b/bench/shbench/sh6bench.patch
@@ -1,5 +1,5 @@
---- sh6bench.c	2026-02-24 11:33:48.525356579 +0000
-+++ sh6bench-new.c	2026-02-24 11:33:48.525356579 +0000
+--- sh6bench.c	2026-02-24 11:57:30.969560311 +0000
++++ sh6bench-new.c	2026-02-24 12:09:31.737552195 +0000
 @@ -50,17 +50,24 @@
  #endif /* SYS_MULTI_THREAD */
 
@@ -45,14 +45,16 @@
  {
 	clock_t startCPU;
 	time_t startTime;
-@@ -195,6 +203,16 @@
+@@ -195,6 +203,18 @@
  #endif
 
 	setbuf(stdout, NULL);  /* turn off buffering for output */
 +#ifdef BENCH
 +	fin = stdin;
 +	fout = stdout;
++#ifdef SYS_MULTI_THREAD
 +	defaultThreadCount = GetNumProcessors();
++#endif
 +	if (argc==2) {
 +		char* end;
 +		long l = strtol(argv[1],&end,10);
@@ -62,7 +64,7 @@
 
 	if (argc > 1)
 		fin = fopen(argv[1], "r");
-@@ -204,6 +222,7 @@
+@@ -204,6 +224,7 @@
 		fout = fopen(argv[2], "w");
 	else
 		fout = stdout;
@@ -70,7 +72,7 @@
 
 	ulCallCount = promptAndRead("call count", ulCallCount, 'u');
 	uMinBlockSize = (unsigned)promptAndRead("min block size",uMinBlockSize,'u');
-@@ -253,7 +272,7 @@
+@@ -253,7 +274,7 @@
 		}
  #endif /* WIN32 */
 
@@ -79,7 +81,7 @@
 
 		if (uThreadCount < 1)
 			uThreadCount = 1;
-@@ -299,6 +318,7 @@
+@@ -299,6 +320,7 @@
 		fclose(fin);
 	if (fout != stdout)
 		fclose(fout);
@@ -87,7 +89,7 @@
  }
 
  void doBench(void *arg)
-@@ -334,11 +354,17 @@
+@@ -334,11 +356,17 @@
 			while (iterations--)
 			{
 
@@ -106,7 +108,7 @@
 
 	  /* while allocating skip over that portion of the buffer that still
 	     holds pointers from the previous cycle
-@@ -387,14 +413,14 @@
+@@ -387,14 +415,14 @@
  {
 	char *arg = NULL, *err;
 	unsigned long result;
@@ -129,7 +131,7 @@
 	if (arg && ((result = strtoul(arg, &err, 10)) != 0
 					|| (*err == '\n' && arg != err)))
 	{
-@@ -429,7 +455,7 @@
+@@ -429,7 +457,7 @@
 							 (pthread_startroutine_t)fn, arg) == -1)
 		 return THREAD_NULL;
 
@@ -138,7 +140,7 @@
 	pthread_attr_t attr;
 	pthread_attr_init(&attr);
  #ifdef _AIX
-@@ -462,7 +488,7 @@
+@@ -462,7 +490,7 @@
 	while (tidCnt--)
 		thr_join(0, NULL, NULL);
 

--- a/bench/shbench/sh8bench.patch
+++ b/bench/shbench/sh8bench.patch
@@ -1,5 +1,5 @@
---- SH8BENCH.C	2026-02-24 11:33:48.649356578 +0000
-+++ sh8bench-new.c	2026-02-24 11:33:48.653356578 +0000
+--- SH8BENCH.C	2026-02-24 12:05:09.973555143 +0000
++++ sh8bench-new.c	2026-02-24 12:09:18.917552340 +0000
 @@ -52,15 +52,18 @@
  #endif /* SYS_MULTI_THREAD */
 
@@ -40,14 +40,16 @@
  {
 	clock_t startCPU;
 	time_t startTime;
-@@ -189,6 +193,16 @@
+@@ -189,6 +193,18 @@
  #endif
 
 	setbuf(stdout, NULL);  /* turn off buffering for output */
 +#ifdef BENCH
 +	fin = stdin;
 +	fout = stdout;
++#ifdef SYS_MULTI_THREAD
 +	defaultThreadCount = GetNumProcessors();
++#endif
 +	if (argc==2) {
 +		char* end;
 +		long l = strtol(argv[1],&end,10);
@@ -57,7 +59,7 @@
 
 	/* @@@ change to use flags specifying which parms are passed */
 
-@@ -200,6 +214,7 @@
+@@ -200,6 +216,7 @@
 		fout = fopen(argv[2], "w");
 	else
 		fout = stdout;
@@ -65,7 +67,7 @@
 
 	if (argc > 3)
 		ulHeapSize = atol(argv[3]);
-@@ -215,15 +230,12 @@
+@@ -215,15 +232,12 @@
 	if (argc > 5)
 		ulThreadCount = atol(argv[5]);
 	else
@@ -84,7 +86,7 @@
  #endif /* SYS_MULTI_THREAD */
 
 	/* @@@
-@@ -386,6 +398,7 @@
+@@ -386,6 +400,7 @@
 		fclose(fin);
 	if (fout != stdout)
 		fclose(fout);
@@ -92,26 +94,26 @@
  }
 
 
-@@ -539,11 +552,17 @@
+@@ -539,11 +554,17 @@
 
 				mp = memory;
 			}
 -			else if (!(*mp++ = (char *)malloc(size)))
-+				else if (!(*mp = (char *)malloc(size)))
++			else if (!(*mp = (char *)malloc(size)))
 			{
 				printf("Out of memory\n");
 				_exit (1);
 			}
-+				else
-+				{
-+					char* p = *mp;
-+					p[0] = 0; p[size-1] = 0;
-+					mp++;
-+				}
++			else
++			{
++				char* p = *mp;
++				p[0] = 0; p[size-1] = 0;
++				mp++;
++			}
 		}
 	}
 
-@@ -571,20 +590,21 @@
+@@ -571,20 +592,21 @@
 	MemPoolCheck(MemDefaultPool);
 	MemPoolCheck(0);
  #endif
@@ -141,7 +143,7 @@
 	if (arg && ((result = strtoul(arg, &err, 10)) != 0
 					|| (*err == '\n' && arg != err)))
 	{
-@@ -619,7 +639,7 @@
+@@ -619,7 +641,7 @@
 							 (pthread_startroutine_t)fn, arg) == -1)
 		 return THREAD_NULL;
 
@@ -150,7 +152,7 @@
 	pthread_attr_t attr;
 	pthread_attr_init(&attr);
  #ifdef _AIX
-@@ -654,7 +674,7 @@
+@@ -654,7 +676,7 @@
 	while (tidCnt--)
 		thr_join(0, NULL, NULL);
 

--- a/bench/shbench/sh8bench.patch
+++ b/bench/shbench/sh8bench.patch
@@ -1,5 +1,5 @@
---- SH8BENCH.C	2026-02-24 12:05:09.973555143 +0000
-+++ sh8bench-new.c	2026-02-24 12:09:18.917552340 +0000
+--- a/SH8BENCH.C	2026-02-24 12:10:48.305551333 +0000
++++ b/sh8bench-new.c	2026-02-24 16:55:10.204940378 +0000
 @@ -52,15 +52,18 @@
  #endif /* SYS_MULTI_THREAD */
 
@@ -132,8 +132,8 @@
 -		if (fgets(buf, 11, fin))
 -			arg = &buf[0];
 -	}
-+#ifndef BENCH
 +	char buf[12];
++#ifndef BENCH
 +	static char fmt[] = "\n%s [%lu]: ";
 +	fmt[7] = fmtCh;
 +	fprintf_silent(fout, fmt, msg, defaultVal);

--- a/bench/shbench/sh8bench.patch
+++ b/bench/shbench/sh8bench.patch
@@ -1,5 +1,5 @@
---- a/SH8BENCH.C	2026-02-24 12:10:48.305551333 +0000
-+++ b/sh8bench-new.c	2026-02-24 16:55:10.204940378 +0000
+--- a/SH8BENCH.C	2026-02-24 16:58:34.360938080 +0000
++++ b/sh8bench-new.c	2026-02-24 17:27:41.317841158 +0000
 @@ -52,15 +52,18 @@
  #endif /* SYS_MULTI_THREAD */
 
@@ -94,7 +94,7 @@
  }
 
 
-@@ -539,11 +554,17 @@
+@@ -539,11 +554,19 @@
 
 				mp = memory;
 			}
@@ -107,13 +107,15 @@
 +			else
 +			{
 +				char* p = *mp;
-+				p[0] = 0; p[size-1] = 0;
++				if (size > 0) {
++					p[0] = 0; p[size-1] = 0;
++				}
 +				mp++;
 +			}
 		}
 	}
 
-@@ -571,20 +592,21 @@
+@@ -571,20 +594,21 @@
 	MemPoolCheck(MemDefaultPool);
 	MemPoolCheck(0);
  #endif
@@ -136,14 +138,14 @@
 +#ifndef BENCH
 +	static char fmt[] = "\n%s [%lu]: ";
 +	fmt[7] = fmtCh;
-+	fprintf_silent(fout, fmt, msg, defaultVal);
++	fprintf(fout, fmt, msg, defaultVal);
 +	if (fgets(buf, 11, fin))
 +		arg = &buf[0];
 +#endif
 	if (arg && ((result = strtoul(arg, &err, 10)) != 0
 					|| (*err == '\n' && arg != err)))
 	{
-@@ -619,7 +641,7 @@
+@@ -619,7 +643,7 @@
 							 (pthread_startroutine_t)fn, arg) == -1)
 		 return THREAD_NULL;
 
@@ -152,7 +154,7 @@
 	pthread_attr_t attr;
 	pthread_attr_init(&attr);
  #ifdef _AIX
-@@ -654,7 +676,7 @@
+@@ -654,7 +678,7 @@
 	while (tidCnt--)
 		thr_join(0, NULL, NULL);
 

--- a/build-bench-env.sh
+++ b/build-bench-env.sh
@@ -189,7 +189,7 @@ while : ; do
         setup_bench=$flag_arg
         setup_packages=$flag_arg
         ;;
-    bench)
+    bench|sh6bench|sh8bench)
         setup_bench=$flag_arg;;
     ff)
         setup_ff=$flag_arg;;
@@ -297,6 +297,8 @@ while : ; do
         echo "  yal                          setup yalloc ($version_yal)"
         echo ""
         echo "  bench                        build all local benchmarks"
+        echo "  sh6bench                     alias for bench"
+        echo "  sh8bench                     alias for bench"
         echo "  lean                         setup lean 3 benchmark"
         echo "  packages                     setup required packages"
         echo "  redis                        setup redis benchmark"


### PR DESCRIPTION
This change fixes several issues with the sh8bench (and sh6bench) benchmarks:
1. Support for 'sh8bench' and 'sh6bench' as direct arguments to build-bench-env.sh.
2. Correction of a bug where ulForeignAllocCount used the wrong command line argument index.
3. Memory safety fixes in promptAndRead (Use-After-Scope).
4. Platform compatibility for Haiku OS, including signal header handling and pthread detection.
5. Robustness fixes to prevent link errors when multi-threading is disabled.
6. Cleaned up patch files with correct hunk headers and indentation matching the source.

---
*PR created automatically by Jules for task [7895843996498065945](https://jules.google.com/task/7895843996498065945) started by @tonestone57*