### PR TITLE
Fix sh6bench and sh8bench for Linux and Haiku OS

### DIFF
--- a/build-bench-env.sh
+++ b/build-bench-env.sh
@@ -189,7 +189,7 @@ while : ; do
         setup_bench=$flag_arg
         setup_packages=$flag_arg
         ;;
-    bench|sh6bench|sh8bench)
+    bench)
         setup_bench=$flag_arg;;
     ff)
         setup_ff=$flag_arg;;
@@ -297,8 +297,6 @@ while : ; do
         echo "  yal                          setup yalloc ($version_yal)"
         echo ""
         echo "  bench                        build all local benchmarks"
-        echo "  sh6bench                     alias for bench"
-        echo "  sh8bench                     alias for bench"
         echo "  lean                         setup lean 3 benchmark"
         echo "  packages                     setup required packages"
         echo "  redis                        setup redis benchmark"


### PR DESCRIPTION
- Update sh6bench.patch and sh8bench.patch to support Haiku OS (signals, pthreads).
- Fix logical bug in sh8bench where argv[6] was ignored for foreign allocations.
- Improve memory safety and realism by touching allocated memory (with size > 0 check).
- Ensure modern C compliance by updating main signatures and return values.
- Fix Use-After-Scope bug in promptAndRead by moving the buffer to function scope.
- Use standard fprintf for better compatibility.
- Ensure pthreads are correctly handled on Haiku.
- Guard GetNumProcessors calls to prevent link errors in non-threaded builds.