### PR TITLE
Fix rpmalloc build for Python 3.13+

### DIFF
--- a/build-bench-env.sh
+++ b/build-bench-env.sh
@@ -744,6 +744,7 @@ fi
 
 if test "$setup_rp" = "1"; then
   checkout rp $version_rp https://github.com/mjansson/rpmalloc
+  patch -p1 -N < ../../patches/rpmalloc_python313.patch || true
   if test -f build.ninja; then
     echo "$devdir/rpmalloc is already configured; no need to reconfigure"
   else

--- a/patches/rpmalloc_python313.patch
+++ b/patches/rpmalloc_python313.patch
@@ -1,0 +1,20 @@
+--- a/build/ninja/generator.py
++++ b/build/ninja/generator.py
+@@ -4,7 +4,7 @@
+
+ import argparse
+ import os
+-import pipes
++import shlex
+ import sys
+
+ import platform
+@@ -82,7 +82,7 @@
+     env_keys = set(['CC', 'AR', 'LINK', 'CFLAGS', 'ARFLAGS', 'LINKFLAGS'])
+     configure_env = dict((key, os.environ[key]) for key in os.environ if key in env_keys)
+     if configure_env:
+-      config_str = ' '.join([key + '=' + pipes.quote(configure_env[key]) for key in configure_env])
++      config_str = ' '.join([key + '=' + shlex.quote(configure_env[key]) for key in configure_env])
+       self.writer.variable('configure_env', config_str + '$ ')
+
+     if variables is None:


### PR DESCRIPTION
Fixed the `ModuleNotFoundError: No module named 'pipes'` error when building rpmalloc on systems with Python 3.13+. This was achieved by creating a patch that replaces the deprecated `pipes.quote` with `shlex.quote` in rpmalloc's ninja build generator, and updating `build-bench-env.sh` to apply this patch.

---
*PR created automatically by Jules for task [2456554235932112451](https://jules.google.com/task/2456554235932112451) started by @tonestone57*