### PR TITLE
Haiku: remove non-existent z3 package from setup script

### DIFF
--- a/build-bench-env.sh
+++ b/build-bench-env.sh
@@ -494,11 +494,11 @@ if test "$setup_packages" = "1"; then
     # sed        -- GNU sed, needed for -E and -i.bak in bench.sh result parsing
     # dos2unix   -- needed to patch shbench source files
     echo ""
-    echo "> pkgman install -y gcc llvm12_clang cmake ninja python3.14 automake libtool autoconf git wget dos2unix bc gmp_devel sed coreutils ruby libatomic_ops_devel time z3 ghostscript snappy_devel readline_devel"
+    echo "> pkgman install -y gcc llvm12_clang cmake ninja python3.14 automake libtool autoconf git wget dos2unix bc gmp_devel sed coreutils ruby libatomic_ops_devel time ghostscript snappy_devel readline_devel"
     echo ""
     pkgman install -y gcc llvm12_clang cmake ninja python3.14 automake libtool autoconf \
       git wget dos2unix bc gmp_devel sed coreutils \
-      ruby libatomic_ops_devel time z3 \
+      ruby libatomic_ops_devel time \
       ghostscript snappy_devel readline_devel
     haikuinstallbazel
     # Allocators not expected to build on Haiku:


### PR DESCRIPTION
Removed the 'z3' package from the 'pkgman install' command in 'build-bench-env.sh' for Haiku. This fixes a build failure on Haiku where the package is unavailable in the repositories. Verified the script syntax and confirmed that 'bench.sh' handles missing 'z3' gracefully.

---
*PR created automatically by Jules for task [4724372409353846955](https://jules.google.com/task/4724372409353846955) started by @tonestone57*