### PR TITLE
Haiku: fix ghostscript package name and remove missing z3

### DIFF
--- a/build-bench-env.sh
+++ b/build-bench-env.sh
@@ -494,12 +494,12 @@ if test "$setup_packages" = "1"; then
     # sed        -- GNU sed, needed for -E and -i.bak in bench.sh result parsing
     # dos2unix   -- needed to patch shbench source files
     echo ""
-    echo "> pkgman install -y gcc llvm12_clang cmake ninja python3.14 automake libtool autoconf git wget dos2unix bc gmp_devel sed coreutils ruby libatomic_ops_devel time ghostscript snappy_devel readline_devel"
+    echo "> pkgman install -y gcc llvm12_clang cmake ninja python3.14 automake libtool autoconf git wget dos2unix bc gmp_devel sed coreutils ruby libatomic_ops_devel time ghostscript_gpl snappy_devel readline_devel"
     echo ""
     pkgman install -y gcc llvm12_clang cmake ninja python3.14 automake libtool autoconf \
       git wget dos2unix bc gmp_devel sed coreutils \
       ruby libatomic_ops_devel time \
-      ghostscript snappy_devel readline_devel
+      ghostscript_gpl snappy_devel readline_devel
     haikuinstallbazel
     # Allocators not expected to build on Haiku:
     #   dh   -- uses __malloc_hook (glibc internal)


### PR DESCRIPTION
- Renamed 'ghostscript' to 'ghostscript_gpl' to match the HaikuPorts package name.
- Removed 'z3' as it is currently unavailable in the standard Haiku repositories.

These changes prevent 'pkgman' from failing during the environment setup on Haiku. bench.sh already handles missing 'z3' gracefully.