### PR TITLE
Haiku: fix setup script and gperftools build

### DIFF
--- a/patches/gperftools_haiku.patch
+++ b/patches/gperftools_haiku.patch
@@ -1,6 +1,15 @@
 --- src/tests/proc_maps_iterator_test.cc
 +++ src/tests/proc_maps_iterator_test.cc
-@@ -69,6 +69,16 @@
+@@ -39,7 +39,7 @@
+ #include "base/generic_writer.h"
+ #include "gtest/gtest.h"
+
+-#if defined __ELF__
++#if defined __ELF__ && !defined __HAIKU__
+ #include <link.h>
+ #define PRINT_DL_PHDRS
+ #endif
+@@ -68,6 +68,16 @@ TEST(ProcMapsIteratorTest, ForEachMapping) {
 
  #ifdef PRINT_DL_PHDRS
 


### PR DESCRIPTION
- Remove non-existent 'z3' package from build-bench-env.sh.
- Rename 'ghostscript' to 'ghostscript_gpl' for Haiku in build-bench-env.sh.
- Update patches/gperftools_haiku.patch to disable PRINT_DL_PHDRS on Haiku to avoid linker errors due to missing dl_iterate_phdr.

These changes ensure the environment can be set up and benchmarks built successfully on Haiku OS.