### PR TITLE
Haiku: comprehensive fixes for packages and allocators (je, tc)

### DIFF
--- a/build-bench-env.sh
+++ b/build-bench-env.sh
@@ -734,6 +734,9 @@ fi
 
 if test "$setup_je" = "1"; then
   checkout je $version_je https://github.com/jemalloc/jemalloc
+  if test "$haiku" = "1"; then
+    patch -p1 -N < ../../patches/jemalloc_haiku.patch || true
+  fi
   if test -f config.status; then
     echo "$devdir/jemalloc is already configured; no need to reconfigure"
   else

--- a/patches/jemalloc_haiku.patch
+++ b/patches/jemalloc_haiku.patch
@@ -1,0 +1,13 @@
+diff --git a/include/jemalloc/internal/jemalloc_internal_decls.h b/include/jemalloc/internal/jemalloc_internal_decls.h
+index 983027c8..21d59b91 100644
+--- a/include/jemalloc/internal/jemalloc_internal_decls.h
++++ b/include/jemalloc/internal/jemalloc_internal_decls.h
+@@ -19,7 +19,7 @@
+ #else
+ #  include <sys/param.h>
+ #  include <sys/mman.h>
+-#  if !defined(__pnacl__) && !defined(__native_client__)
++#  if !defined(__pnacl__) && !defined(__native_client__) && !defined(__HAIKU__)
+ #    include <sys/syscall.h>
+ #    if !defined(SYS_write) && defined(__NR_write)
+ #      define SYS_write __NR_write


### PR DESCRIPTION
- Fixed package installation by removing missing 'z3' and renaming 'ghostscript' to 'ghostscript_gpl' in build-bench-env.sh.
- Fixed 'gperftools' (tc) build by disabling 'dl_iterate_phdr' usage on Haiku in patches/gperftools_haiku.patch.
- Fixed 'jemalloc' (je) build by guarding 'sys/syscall.h' inclusion in patches/jemalloc_haiku.patch.

These changes enable a successful environment setup and build for multiple allocators on Haiku OS.