### PR TITLE
Fix various allocator failures on Haiku OS

### DIFF
--- a/build-bench-env.sh
+++ b/build-bench-env.sh
@@ -583,6 +583,9 @@ fi
 
 if test "$setup_ff" = "1"; then
   checkout ff $version_ff https://github.com/bwickman97/ffmalloc
+  if test "$haiku" = "1"; then
+    patch -p1 -l -N < "$curdir/patches/ffmalloc_haiku.patch" || true
+  fi
   make -j $procs
   popd
 fi
@@ -673,6 +676,9 @@ fi
 
 if test "$setup_sg" = "1"; then
   checkout sg $version_sg https://github.com/ssrg-vt/SlimGuard
+  if test "$haiku" = "1"; then
+    patch -p1 -l -N < "$curdir/patches/slimguard_haiku.patch" || true
+  fi
   make -j $procs
   popd
 fi
@@ -743,7 +749,11 @@ if test "$setup_je" = "1"; then
   if test -f config.status; then
     echo "$devdir/jemalloc is already configured; no need to reconfigure"
   else
-    ./autogen.sh --enable-doc=no --enable-static=no --disable-stats
+    je_cfg="--enable-doc=no --enable-static=no --disable-stats"
+    if test "$haiku" = "1"; then
+      je_cfg="$je_cfg --disable-initial-exec-tls"
+    fi
+    ./autogen.sh $je_cfg
   fi
   make -j $procs
   [ "$CI" ] && rm -rf ./src/*.o  # jemalloc has like ~100MiB of object files

--- a/patches/ffmalloc_haiku.patch
+++ b/patches/ffmalloc_haiku.patch
@@ -1,0 +1,13 @@
+--- a/ffmalloc.c
++++ b/ffmalloc.c
+@@ -1136,7 +1136,11 @@
+
+ // Returns the index of the large list index to use based on the current CPU
+ static unsigned int get_large_list_index() {
++#ifdef __HAIKU__
++	int cpuId = 0;
++#else
+	int cpuId = sched_getcpu();
++#endif
+	return cpuId < 0 ? 0 : (unsigned int)cpuId % MAX_LARGE_LISTS;
+ }

--- a/patches/ffmalloc_haiku.patch
+++ b/patches/ffmalloc_haiku.patch
@@ -1,6 +1,6 @@
 --- a/ffmalloc.c
 +++ b/ffmalloc.c
-@@ -1136,7 +1136,11 @@
+@@ -1137,7 +1137,11 @@
 
  // Returns the index of the large list index to use based on the current CPU
  static unsigned int get_large_list_index() {

--- a/patches/hardened_malloc_haiku.patch
+++ b/patches/hardened_malloc_haiku.patch
@@ -1,16 +1,19 @@
-diff --git a/Makefile b/Makefile
-index b5408a2..e124c64 100644
---- a/Makefile
-+++ b/Makefile
-@@ -1,3 +1,8 @@
-+ifeq ($(shell uname -s), Haiku)
-+    CFLAGS += -ftls-model=global-dynamic
-+    CXXFLAGS += -ftls-model=global-dynamic
-+endif
-+
- VARIANT := default
+diff --git a/h_malloc.c b/h_malloc.c
+index 2d995ef..42dff4e 100644
+--- a/h_malloc.c
++++ b/h_malloc.c
+@@ -61,7 +61,11 @@
+ #define CACHELINE_SIZE 64
 
- ifneq ($(VARIANT),)
+ #if N_ARENA > 1
++#ifdef __HAIKU__
++__attribute__((tls_model("global-dynamic")))
++#else
+ __attribute__((tls_model("initial-exec")))
++#endif
+ static thread_local unsigned thread_arena = N_ARENA;
+ static atomic_uint thread_arena_counter = 0;
+ #else
 diff --git a/memory.c b/memory.c
 index 2d995ef..42dff4e 100644
 --- a/memory.c

--- a/patches/hardened_malloc_haiku.patch
+++ b/patches/hardened_malloc_haiku.patch
@@ -1,3 +1,16 @@
+diff --git a/Makefile b/Makefile
+index b5408a2..e124c64 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,3 +1,8 @@
++ifeq ($(shell uname -s), Haiku)
++    CFLAGS += -ftls-model=global-dynamic
++    CXXFLAGS += -ftls-model=global-dynamic
++endif
++
+ VARIANT := default
+
+ ifneq ($(VARIANT),)
 diff --git a/memory.c b/memory.c
 index 2d995ef..42dff4e 100644
 --- a/memory.c

--- a/patches/iso_alloc_haiku.patch
+++ b/patches/iso_alloc_haiku.patch
@@ -24,7 +24,7 @@ index 82843a3..a32849b 100644
 
  ## Build a debug version of the library
 diff --git a/src/iso_alloc.c b/src/iso_alloc.c
-index a210b64..f500a8c 100644
+index 5e1f8fa..c291d02 100644
 --- a/src/iso_alloc.c
 +++ b/src/iso_alloc.c
 @@ -13,7 +13,7 @@
@@ -59,11 +59,10 @@ index 408c92b..e3a50b5 100644
      arc4random_buf(&val, sizeof(val));
  #endif
 diff --git a/src/iso_alloc_sanity.c b/src/iso_alloc_sanity.c
-index 8e46123..d949216 100644
+index b8b38aa..4d97204 100644
 --- a/src/iso_alloc_sanity.c
 +++ b/src/iso_alloc_sanity.c
 @@ -13,7 +13,7 @@
- #if THREAD_SUPPORT
  #if USE_SPINLOCK
  atomic_flag sane_cache_flag;
  #else

--- a/patches/iso_alloc_haiku.patch
+++ b/patches/iso_alloc_haiku.patch
@@ -23,6 +23,19 @@ index 82843a3..a32849b 100644
 	$(STRIP)
 
  ## Build a debug version of the library
+diff --git a/src/iso_alloc.c b/src/iso_alloc.c
+index a210b64..f500a8c 100644
+--- a/src/iso_alloc.c
++++ b/src/iso_alloc.c
+@@ -13,7 +13,7 @@
+ #if USE_SPINLOCK
+ atomic_flag root_busy_flag;
+ #else
+-pthread_mutex_t root_busy_mutex;
++pthread_mutex_t root_busy_mutex = PTHREAD_MUTEX_INITIALIZER;
+ #endif
+ /* We cannot initialize this on thread creation so
+  * we can't mmap them somewhere with guard pages but
 diff --git a/src/iso_alloc_random.c b/src/iso_alloc_random.c
 index 408c92b..e3a50b5 100644
 --- a/src/iso_alloc_random.c
@@ -44,4 +57,17 @@ index 408c92b..e3a50b5 100644
 +#elif __NetBSD__ || __HAIKU__
      /* Temporary solution until NetBSD 10 released with getrandom support */
      arc4random_buf(&val, sizeof(val));
+ #endif
+diff --git a/src/iso_alloc_sanity.c b/src/iso_alloc_sanity.c
+index 8e46123..d949216 100644
+--- a/src/iso_alloc_sanity.c
++++ b/src/iso_alloc_sanity.c
+@@ -13,7 +13,7 @@
+ #if THREAD_SUPPORT
+ #if USE_SPINLOCK
+ atomic_flag sane_cache_flag;
+ #else
+-pthread_mutex_t sane_cache_mutex;
++pthread_mutex_t sane_cache_mutex = PTHREAD_MUTEX_INITIALIZER;
+ #endif
  #endif

--- a/patches/slimguard_haiku.patch
+++ b/patches/slimguard_haiku.patch
@@ -1,11 +1,17 @@
+diff --git a/include/slimguard.h b/include/slimguard.h
+index d63f1c7..d246698 100644
 --- a/include/slimguard.h
 +++ b/include/slimguard.h
-@@ -16,6 +16,33 @@
+@@ -15,6 +15,37 @@
  #include <time.h>
  #include <math.h>
 
 +#ifdef __HAIKU__
 +#include <stdarg.h>
++#include <stdlib.h>
++#include <stdio.h>
++#include <string.h>
++#include <errno.h>
 +static inline void warnx(const char *fmt, ...) {
 +    va_list ap;
 +    va_start(ap, fmt);
@@ -36,6 +42,8 @@
  #define ETP (8) // entropy to 8 bits
  #define GP (10) // 1 guard page per GP pages
  #define BKT (1 << ETP) // bucket size
+diff --git a/src/slimguard-mmap.c b/src/slimguard-mmap.c
+index fa0a533..b2ec78e 100644
 --- a/src/slimguard-mmap.c
 +++ b/src/slimguard-mmap.c
 @@ -1,7 +1,9 @@

--- a/patches/slimguard_haiku.patch
+++ b/patches/slimguard_haiku.patch
@@ -1,0 +1,49 @@
+--- a/include/slimguard.h
++++ b/include/slimguard.h
+@@ -16,6 +16,33 @@
+ #include <time.h>
+ #include <math.h>
+
++#ifdef __HAIKU__
++#include <stdarg.h>
++static inline void warnx(const char *fmt, ...) {
++    va_list ap;
++    va_start(ap, fmt);
++    vfprintf(stderr, fmt, ap);
++    va_end(ap);
++    fprintf(stderr, "\n");
++}
++
++static inline void warn(const char *fmt, ...) {
++    va_list ap;
++    int saved_errno = errno;
++    va_start(ap, fmt);
++    vfprintf(stderr, fmt, ap);
++    va_end(ap);
++    fprintf(stderr, ": %s\n", strerror(saved_errno));
++}
++
++static inline void errx(int eval, const char *fmt, ...) {
++    va_list ap;
++    va_start(ap, fmt);
++    vfprintf(stderr, fmt, ap);
++    va_end(ap);
++    fprintf(stderr, "\n");
++    exit(eval);
++}
++#endif
++
+ #define ETP (8) // entropy to 8 bits
+ #define GP (10) // 1 guard page per GP pages
+ #define BKT (1 << ETP) // bucket size
+--- a/src/slimguard-mmap.c
++++ b/src/slimguard-mmap.c
+@@ -1,7 +1,9 @@
+ #include "slimguard-mmap.h"
+ #include "slimguard.h"
+
++#ifndef __HAIKU__
+ #include <err.h>
++#endif
+ #include <sys/mman.h>
+ #include <stdlib.h>

--- a/patches/snmalloc_haiku.patch
+++ b/patches/snmalloc_haiku.patch
@@ -1,10 +1,17 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index cad25ef..5af2fe8 100644
+index cad25ef..e587c9a 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -550,11 +550,11 @@ if(NOT SNMALLOC_HEADER_ONLY_LIBRARY)
-       SNMALLOC_CHECK_LOADS=$<IF:$<BOOL:${SNMALLOC_CHECK_LOADS}>,true,false>)
-     target_compile_definitions(${name} PRIVATE
+@@ -532,7 +532,7 @@ if(NOT SNMALLOC_HEADER_ONLY_LIBRARY)
+       endif()
+
+       # Static TLS model is unsupported on Haiku.
+-      if (SNMALLOC_STATIC_MODE_TLS)
++      if (SNMALLOC_STATIC_MODE_TLS AND NOT CMAKE_SYSTEM_NAME STREQUAL "Haiku")
+         target_compile_options(${name} PRIVATE -ftls-model=initial-exec)
+         target_compile_options(${name} PRIVATE $<$<BOOL:${SNMALLOC_CI_BUILD}>:-g>)
+       endif()
+@@ -552,7 +552,7 @@ if(NOT SNMALLOC_HEADER_ONLY_LIBRARY)
        SNMALLOC_PAGEID=$<IF:$<BOOL:${SNMALLOC_PAGEID}>,true,false>)
 
      if(MSVC)
@@ -13,5 +20,3 @@ index cad25ef..5af2fe8 100644
        # We can't do --nostdlib++ as we are using exceptions, but we
        # can make it a static dependency, which we aren't really using
        # as the interesting stuff for exceptions is in libgcc_s
-       target_link_options(${name} PRIVATE -static-libstdc++)
-     endif()


### PR DESCRIPTION
This submission fixes various build and runtime issues encountered when running the mimalloc-bench suite on Haiku OS. 

The main fixes include:
1. Providing fallbacks for missing glibc/BSD-specific functions like `sched_getcpu` and `warnx`.
2. Disabling the `initial-exec` Thread-Local Storage (TLS) model for allocators intended to be used via `LD_PRELOAD`, as Haiku's runtime loader does not support it for dynamically loaded libraries.
3. Statically initializing global mutexes in `isoalloc` to prevent crashes when `malloc` is called before the library's constructor.
4. Correcting flag application in the `hardened_malloc` Makefile for Haiku.
5. Updating `build-bench-env.sh` to apply these new patches and pass necessary configuration flags.

---
*PR created automatically by Jules for task [17046894681896679031](https://jules.google.com/task/17046894681896679031) started by @tonestone57*