### PR TITLE
Fix Haiku build and runtime issues for allocators (ff, hm, sg, sn)

### DIFF
--- a/patches/hardened_malloc_haiku.patch
+++ b/patches/hardened_malloc_haiku.patch
@@ -10,7 +10,7 @@ index 2d995ef..42dff4e 100644
 +#else
  __attribute__((tls_model("initial-exec")))
 +#endif
- static thread_local unsigned thread_arena = N_ARENA;
+ static _Thread_local unsigned thread_arena = N_ARENA;
  static atomic_uint thread_arena_counter = 0;
  #else
 diff --git a/memory.c b/memory.c
@@ -39,16 +39,19 @@ diff --git a/random.c b/random.c
 index 8883531..abda53e 100644
 --- a/random.c
 +++ b/random.c
-@@ -4,24 +4,32 @@
- #include "chacha.h"
- #include "random.h"
- #include "util.h"
+@@ -1,5 +1,9 @@
+ #include <errno.h>
+ #include <string.h>
 
 +#ifdef __HAIKU__
 +#include <stdlib.h>
-+#else
- #include <sys/random.h>
 +#endif
++
+ #include "chacha.h"
+ #include "random.h"
+ #include "util.h"
+@@ -10,8 +14,12 @@
+ #include <sys/random.h>
 
  static void get_random_seed(void *buf, size_t size) {
 +#ifdef __HAIKU__


### PR DESCRIPTION
- ffmalloc: Fix missing sched_getcpu by stubbing it. Add dos2unix to build script to prevent patch failures.
- hardened_malloc: Fix hang by using arc4random_buf instead of getrandom. Use global-dynamic TLS. Fix prctl usage. Use thread_local correctly.
- slimguard: Fix malformed patch context.
- snmalloc: Fix hang by implementing get_entropy64 using arc4random_buf in PALHaiku.