### PR TITLE
Haiku page fault telemetry fallback

### DIFF
--- a/scripts/haiku-time.c
+++ b/scripts/haiku-time.c
@@ -46,6 +46,8 @@ int main(int argc, char** argv) {
     struct rusage start_ru;
     getrusage(RUSAGE_CHILDREN, &start_ru);
     bigtime_t start_real = system_time();
+    system_info start_si;
+    get_system_info(&start_si);
 
     pid_t pid = fork();
     if (pid < 0) {
@@ -78,6 +80,8 @@ int main(int argc, char** argv) {
     bigtime_t end_real = system_time();
     struct rusage end_ru;
     getrusage(RUSAGE_CHILDREN, &end_ru);
+    system_info end_si;
+    get_system_info(&end_si);
 
     double elapsed = (end_real - start_real) / 1000000.0;
     double user_time = (end_ru.ru_utime.tv_sec - start_ru.ru_utime.tv_sec) +
@@ -90,6 +94,10 @@ int main(int argc, char** argv) {
     long majflt = end_ru.ru_majflt;
 
     /* Fallback for older Haiku where rusage fields are 0 */
+    if (minflt == 0 && majflt == 0) {
+        majflt = (long)(end_si.page_faults - start_si.page_faults);
+    }
+
     if (max_rss <= 0) {
         max_rss = (long)(peak_rss / 1024);
     }


### PR DESCRIPTION
Implemented a fallback mechanism for page fault reporting on Haiku OS. Since 'getrusage' does not always provide these metrics on Haiku, the 'haiku-time' wrapper now calculates the delta of system-wide page faults using 'get_system_info' and reports it if per-process metrics are unavailable.

---
*PR created automatically by Jules for task [12587482176707149992](https://jules.google.com/task/12587482176707149992) started by @tonestone57*