### PR TITLE
Fix snmalloc Haiku build and address nitpicks

### DIFF
--- a/patches/snmalloc_haiku.patch
+++ b/patches/snmalloc_haiku.patch
@@ -1,17 +1,26 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index cad25ef..856cb95 100644
+index cad25ef..7885a5d 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -294,7 +294,7 @@ target_include_directories(snmalloc
+@@ -290,13 +290,13 @@ target_include_directories(snmalloc
+   INTERFACE
+     $<INSTALL_INTERFACE:include/snmalloc>
+     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>)
+
  if(NOT MSVC)
-   find_package(Threads REQUIRED COMPONENTS snmalloc)
+-  find_package(Threads REQUIRED COMPONENTS snmalloc)
++  find_package(Threads REQUIRED)
    target_link_libraries(snmalloc INTERFACE
 -    ${CMAKE_THREAD_LIBS_INIT} $<$<CXX_COMPILER_ID:GNU>:atomic>)
 +    ${CMAKE_THREAD_LIBS_INIT} $<$<CXX_COMPILER_ID:GNU>:atomic> $<$<PLATFORM_ID:Haiku>:bsd>)
  endif()
 
  if (WIN32)
-@@ -532,7 +532,7 @@ if(NOT SNMALLOC_HEADER_ONLY_LIBRARY)
+   set(WIN8COMPAT FALSE CACHE BOOL "Avoid Windows 10 APIs")
+   target_compile_definitions(snmalloc INTERFACE $<$<BOOL:${WIN8COMPAT}>:WINVER=0x0603>)
+@@ -530,11 +530,11 @@ if(NOT SNMALLOC_HEADER_ONLY_LIBRARY)
+       if (SUPPORT_PREFETCH_WRITE)
+         target_compile_options(${name} PRIVATE -mprfchw)
        endif()
 
        # Static TLS model is unsupported on Haiku.
@@ -20,20 +29,30 @@ index cad25ef..856cb95 100644
          target_compile_options(${name} PRIVATE -ftls-model=initial-exec)
          target_compile_options(${name} PRIVATE $<$<BOOL:${SNMALLOC_CI_BUILD}>:-g>)
        endif()
-@@ -552,7 +552,7 @@ if(NOT SNMALLOC_HEADER_ONLY_LIBRARY)
+
+       if(SNMALLOC_OPTIMISE_FOR_CURRENT_MACHINE)
+@@ -550,12 +550,12 @@ if(NOT SNMALLOC_HEADER_ONLY_LIBRARY)
+       SNMALLOC_CHECK_LOADS=$<IF:$<BOOL:${SNMALLOC_CHECK_LOADS}>,true,false>)
+     target_compile_definitions(${name} PRIVATE
        SNMALLOC_PAGEID=$<IF:$<BOOL:${SNMALLOC_PAGEID}>,true,false>)
 
      if(MSVC)
 -    else()
+-      # We can't do --nostdlib++ as we are using exceptions, but we
 +    elseif(NOT CMAKE_SYSTEM_NAME STREQUAL "Haiku")
-       # We can't do --nostdlib++ as we are using exceptions, but we
++      # We can't do --nostdlib++ as we are using exceptions, but we
        # can make it a static dependency, which we aren't really using
        # as the interesting stuff for exceptions is in libgcc_s
+       target_link_options(${name} PRIVATE -static-libstdc++)
+     endif()
+
 diff --git a/src/snmalloc/pal/pal_haiku.h b/src/snmalloc/pal/pal_haiku.h
 index bbc9e07..67429df 100644
 --- a/src/snmalloc/pal/pal_haiku.h
 +++ b/src/snmalloc/pal/pal_haiku.h
-@@ -37,6 +37,13 @@ namespace snmalloc
+@@ -35,8 +35,15 @@ namespace snmalloc
+     static void notify_not_using(void* p, size_t size) noexcept
+     {
        SNMALLOC_ASSERT(is_aligned_block<page_size>(p, size));
        posix_madvise(p, size, POSIX_MADV_DONTNEED);
      }


### PR DESCRIPTION
This commit updates `patches/snmalloc_haiku.patch` to:
1. Resolve undefined reference errors to `arc4random_buf` on Haiku by linking against `libbsd`.
2. Implement `get_entropy64` in `PALHaiku` using `arc4random_buf`.
3. Disable `initial-exec` TLS and `-static-libstdc++` on Haiku.
4. Address upstream nitpicks:
   - Remove invalid `COMPONENTS snmalloc` from `find_package(Threads)`.
   - Remove trailing whitespace in `CMakeLists.txt` comments.

The patch was regenerated against snmalloc 0.7.3 to ensure clean application.