### PR TITLE
haiku: fix snmalloc hang by avoiding recursion in entropy gathering

### DIFF
--- a/patches/snmalloc_haiku.patch
+++ b/patches/snmalloc_haiku.patch
@@ -74,20 +74,18 @@ index cad25ef..0ede398 100644
        # can make it a static dependency, which we aren't really using
        # as the interesting stuff for exceptions is in libgcc_s
 diff --git a/src/snmalloc/pal/pal_haiku.h b/src/snmalloc/pal/pal_haiku.h
-index bbc9e07..121b0a9 100644
+index bbc9e07..39f3605 100644
 --- a/src/snmalloc/pal/pal_haiku.h
 +++ b/src/snmalloc/pal/pal_haiku.h
-@@ -37,6 +37,13 @@ namespace snmalloc
+@@ -37,6 +37,11 @@ namespace snmalloc
        SNMALLOC_ASSERT(is_aligned_block<page_size>(p, size));
        posix_madvise(p, size, POSIX_MADV_DONTNEED);
      }
++
 +    static uint64_t get_entropy64() noexcept
 +    {
-+      uint64_t result;
-+      arc4random_buf(&result, sizeof(result));
-+      return result;
++      return PALPOSIX::dev_urandom();
 +    }
-+
    };
  } // namespace snmalloc
  #endif


### PR DESCRIPTION
Haiku's `arc4random_buf` and `getentropy` can call `malloc`, leading to a deadlock during `snmalloc` initialization when it's used as an `LD_PRELOAD` library.

This change updates `PALHaiku::get_entropy64` to use `dev_urandom()` from the POSIX PAL, which directly reads from `/dev/urandom` using system calls (`open`, `read`, `close`), avoiding any recursion into the allocator itself.

Also includes previously addressed configuration noise fixes for `Backtrace`, `LLD_WORKS`, and `SUPPORT_PREFETCH_WRITE` on Haiku.