### PR TITLE
Fix snmalloc deadlock on Haiku OS

### DIFF
--- a/patches/snmalloc_haiku.patch
+++ b/patches/snmalloc_haiku.patch
@@ -74,17 +74,27 @@ index cad25ef..0ede398 100644
        # can make it a static dependency, which we aren't really using
        # as the interesting stuff for exceptions is in libgcc_s
 diff --git a/src/snmalloc/pal/pal_haiku.h b/src/snmalloc/pal/pal_haiku.h
-index bbc9e07..39f3605 100644
+index bbc9e07..0c0156d 100644
 --- a/src/snmalloc/pal/pal_haiku.h
 +++ b/src/snmalloc/pal/pal_haiku.h
-@@ -37,6 +37,11 @@ namespace snmalloc
+@@ -3,6 +3,7 @@
+ #if defined(__HAIKU__)
+
+ #  include "pal_posix.h"
++#  include <stdlib.h>
+
+ #  include <sys/mman.h>
+
+@@ -37,6 +38,13 @@ namespace snmalloc
        SNMALLOC_ASSERT(is_aligned_block<page_size>(p, size));
        posix_madvise(p, size, POSIX_MADV_DONTNEED);
      }
 +
 +    static uint64_t get_entropy64() noexcept
 +    {
-+      return PALPOSIX::dev_urandom();
++      uint64_t seed;
++      arc4random_buf(&seed, sizeof(seed));
++      return seed;
 +    }
    };
  } // namespace snmalloc


### PR DESCRIPTION
Diagnosed and resolved a deadlock/livelock issue in `snmalloc` on Haiku OS. The root cause was identified as the use of file-based entropy (`/dev/urandom`) during early allocator initialization, which is prone to deadlocks. The fix involves updating the Haiku-specific patch to utilize `arc4random_buf` instead. The fix was verified for clean application, compilation, and functional correctness on a Linux host with appropriate mocking. Instructions for enabling verbose tracing were also verified and documented.

---
*PR created automatically by Jules for task [726235223912123329](https://jules.google.com/task/726235223912123329) started by @tonestone57*