### PR TITLE
Fix Lean 3 crash on Haiku OS

### DIFF
--- a/build-bench-env.sh
+++ b/build-bench-env.sh
@@ -1005,6 +1005,7 @@ if test "$setup_lean" = "1"; then
   checkout lean $version_lean https://github.com/leanprover-community/lean
   patch -p1 -l -N < "$curdir/patches/lean_alpine.patch" || true
   if test "$haiku" = "1"; then
+    patch -p1 -l -N < "$curdir/patches/lean_haiku.patch" || true
     ensure_haiku_tool cmake cmake
   fi
   mkdir -p out/release

--- a/patches/lean_haiku.patch
+++ b/patches/lean_haiku.patch
@@ -1,0 +1,27 @@
+--- a/src/util/path.cpp	2026-03-01 10:04:11.918997825 +0000
++++ b/src/util/path.cpp	2026-03-01 10:04:12.250997822 +0000
+@@ -72,6 +72,24 @@
+     return std::string(buf2);
+ }
+ bool is_path_sep(char c) { return c == g_path_sep; }
++#elif defined(__HAIKU__)
++// Haiku version
++#include <image.h>
++#include <OS.h>
++static char g_path_sep     = ':';
++static constexpr char g_sep          = '/';
++static char g_bad_sep      = '\\';
++std::string get_exe_location() {
++    image_info info;
++    int32 cookie = 0;
++    while (get_next_image_info(0, &cookie, &info) == B_OK) {
++        if (info.type == B_APP_IMAGE) {
++            return std::string(info.name);
++        }
++    }
++    throw exception("failed to locate Lean executable location");
++}
++bool is_path_sep(char c) { return c == g_path_sep; }
+ #else
+ // Linux version
+ #include <unistd.h>


### PR DESCRIPTION
Implement `get_exe_location` for Haiku OS in Lean 3 to resolve a crash during the build process. Added `patches/lean_haiku.patch` and updated `build-bench-env.sh` to apply it.

---
*PR created automatically by Jules for task [15618732322643613181](https://jules.google.com/task/15618732322643613181) started by @tonestone57*