### PR TITLE
fix: implement get_exe_location for Haiku OS in Lean 3 and fix iso al…

### DIFF
--- a/patches/iso_alloc_haiku.patch
+++ b/patches/iso_alloc_haiku.patch
@@ -1,5 +1,5 @@
---- Makefile	2026-03-01 12:16:11.237844810 +0000
-+++ Makefile	2026-03-01 12:16:11.341844809 +0000
+--- a/Makefile	2026-03-01 12:16:11.237844810 +0000
++++ b/Makefile	2026-03-01 12:16:11.341844809 +0000
 @@ -230,6 +230,11 @@
  OS_FLAGS = -I/usr/local/cxx_atomics
  endif
@@ -21,8 +21,8 @@
 	$(STRIP)
 
  ## Build a debug version of the library
---- src/iso_alloc.c	2026-03-01 12:16:11.257844810 +0000
-+++ src/iso_alloc.c	2026-03-01 12:16:11.705844805 +0000
+--- a/src/iso_alloc.c	2026-03-01 12:16:11.257844810 +0000
++++ b/src/iso_alloc.c	2026-03-01 12:16:11.705844805 +0000
 @@ -13,7 +13,7 @@
  #if USE_SPINLOCK
  atomic_flag root_busy_flag;
@@ -32,8 +32,8 @@
  #endif
  /* We cannot initialize this on thread creation so
   * we can't mmap them somewhere with guard pages but
---- src/iso_alloc_sanity.c	2026-03-01 12:16:11.261844810 +0000
-+++ src/iso_alloc_sanity.c	2026-03-01 12:16:11.973844802 +0000
+--- a/src/iso_alloc_sanity.c	2026-03-01 12:16:11.261844810 +0000
++++ b/src/iso_alloc_sanity.c	2026-03-01 12:16:11.973844802 +0000
 @@ -13,7 +13,7 @@
  #if USE_SPINLOCK
  atomic_flag sane_cache_flag;
@@ -43,8 +43,8 @@
  #endif
  #endif
 
---- src/iso_alloc_random.c	2026-03-01 12:16:11.261844810 +0000
-+++ src/iso_alloc_random.c	2026-03-01 12:16:12.245844799 +0000
+--- a/src/iso_alloc_random.c	2026-03-01 12:16:11.261844810 +0000
++++ b/src/iso_alloc_random.c	2026-03-01 12:16:12.245844799 +0000
 @@ -15,7 +15,7 @@
  #include <Security/SecRandom.h>
  #elif __FreeBSD__ || __DragonFly__ || __linux__ || __ANDROID__


### PR DESCRIPTION
…locator build

This change adds a Haiku-specific implementation of `get_exe_location` in `src/util/path.cpp` using the `get_next_image_info` API. This resolves a crash where Lean fails to locate its own executable, which is necessary for it to find its standard library during the build process.

Additionally, this change fixes the build for the `iso` allocator on Haiku OS by:
- Correcting `patches/iso_alloc_haiku.patch` with proper diff headers (`a/`, `b/` prefixes).
- Initializing global mutexes (`root_busy_mutex`, `sane_cache_mutex`) with `PTHREAD_MUTEX_INITIALIZER` to avoid assertion failures.
- Providing a Haiku-compatible entropy implementation in `src/iso_alloc_random.c` using `arc4random_buf`.
- Updating the `Makefile` to link against `libbsd` and reordering linker flags.

Summary of changes:
- Created `patches/lean_haiku.patch` for Lean 3.
- Updated `build-bench-env.sh` to apply the Lean 3 patch on Haiku.
- Fixed `patches/iso_alloc_haiku.patch` for `isoalloc`.
- Verified both builds complete successfully on Haiku.