### PR TITLE
Fix tc allocator crash on Haiku

### DIFF
--- a/build-bench-env.sh
+++ b/build-bench-env.sh
@@ -735,7 +735,7 @@ fi
 
 if test "$setup_tc" = "1"; then
   checkout tc $version_tc https://github.com/gperftools/gperftools
-  patch -p0 -l -N < "$curdir/patches/gperftools_haiku.patch" || true
+  patch -p1 -l -N < "$curdir/patches/gperftools_haiku.patch" || true
   if test -f configure; then
     echo "already configured"
   else

--- a/patches/gperftools_haiku.patch
+++ b/patches/gperftools_haiku.patch
@@ -1,5 +1,20 @@
---- src/tests/proc_maps_iterator_test.cc
-+++ src/tests/proc_maps_iterator_test.cc
+--- a/src/base/basictypes.h
++++ b/src/base/basictypes.h
+@@ -85,7 +85,11 @@
+ #endif
+
+ #if defined(HAVE___ATTRIBUTE__)
+-#define ATTR_INITIAL_EXEC __attribute__ ((tls_model ("initial-exec")))
++# if defined(__HAIKU__)
++#  define ATTR_INITIAL_EXEC __attribute__ ((tls_model ("global-dynamic")))
++# else
++#  define ATTR_INITIAL_EXEC __attribute__ ((tls_model ("initial-exec")))
++# endif
+ #else
+ #define ATTR_INITIAL_EXEC
+ #endif
+--- a/src/tests/proc_maps_iterator_test.cc
++++ b/src/tests/proc_maps_iterator_test.cc
 @@ -39,7 +39,7 @@
  #include "base/generic_writer.h"
  #include "gtest/gtest.h"
@@ -9,7 +24,7 @@
  #include <link.h>
  #define PRINT_DL_PHDRS
  #endif
-@@ -68,6 +68,16 @@ TEST(ProcMapsIteratorTest, ForEachMapping) {
+@@ -68,6 +68,16 @@
 
  #ifdef PRINT_DL_PHDRS
 


### PR DESCRIPTION
Fixed a "Segment violation" crash in the tc (tcmalloc) allocator on Haiku. The crash was caused by the use of the 'initial-exec' TLS model in a preloaded shared library, which Haiku's runtime loader does not fully support. The fix involved patching gperftools to use the 'global-dynamic' TLS model on Haiku and updating the build script to apply this patch correctly.

---
*PR created automatically by Jules for task [16137951270546368032](https://jules.google.com/task/16137951270546368032) started by @tonestone57*