### PR TITLE
Fix benchmark suite regressions and nitpicks

### DIFF
--- a/bench.sh
+++ b/bench.sh
@@ -6,8 +6,8 @@
 # Allocators and tests
 # --------------------------------------------------------------------
 
-readonly alloc_all="sys dh ff fg gd hd hm hml iso je lf lp lt mi mi-sec mi2 mi2-sec mi3 mi3-sec mng mesh nomesh pa rp sc scudo sg sm sn sn-sec sn-dbg tbb tc tcg mi-dbg mi2-dbg mi3-dbg xmi xsmi xmi-dbg yal"
-readonly alloc_secure="dh ff gd hm hml iso mi-sec mi2-sec mi3-sec mng pa scudo sg sn-sec sg"
+readonly alloc_all="sys dh ff fg gd hd hm hml iso je lf lp lt mi mi-sec mi2 mi2-sec mi3 mi3-sec mng mesh nomesh pa rp sc scudo sg sm sn sn-sec sn-dbg tbb tc tcg mi-dbg mi2-dbg mi3-dbg xmi xmi-sec xmi-dbg yal"
+readonly alloc_secure="dh ff gd hm hml iso mi-sec mi2-sec mi3-sec mng pa scudo sg sn-sec"
 alloc_run=""           # allocators to run (expanded by command line options)
 alloc_installed="sys"  # later expanded to include all installed allocators
 alloc_libs="sys="      # mapping from allocator to its .so as "<allocator>=<sofile> ..."

--- a/graph_many.py
+++ b/graph_many.py
@@ -2,11 +2,6 @@ import re
 import sys
 import collections
 try:
-    import numpy as np 
-except ImportError:
-    print('You need to install numpy.')
-    sys.exit(1)
-try:
     import plotly.express as px
 except ImportError:
     print('You need to install plotly.express.')
@@ -35,6 +30,15 @@ if len(sys.argv) != 2:
     print('The normalised time/memory uses a log scale.')
     sys.exit(1)
 
+def parse_time(time_string):
+    parts = time_string.split(':')
+    if len(parts) == 3: # H:MM:SS.ss
+        return int(parts[0]) * 3600 + int(parts[1]) * 60 + float(parts[2])
+    elif len(parts) == 2: # MM:SS.ss
+        return int(parts[0]) * 60 + float(parts[1])
+    else:
+        return float(parts[0])
+
 parse_line = re.compile('^([^ ]+) +([^ ]+) +([0-9:.]+) +([0-9]+)')
 data = []
 test_names = set()
@@ -46,13 +50,8 @@ with open(sys.argv[1]) as f:
         if not match:
             continue
         test_name, alloc_name, time_string, memory = match.groups()
-        time_split = time_string.split(':')
-        time_taken = 0
+        time_taken = parse_time(time_string)
         test_names.add(test_name)
-        if len(time_split) == 2:
-            time_taken = int(time_split[0]) * 60 + float(time_split[1])
-        else:
-            time_taken = float(time_split[0])
         data.append({"Benchmark":test_name, "Allocator":alloc_name, "Time":time_taken, "Memory":int(memory)})
 
 # create a dictionary of means
@@ -60,13 +59,17 @@ time_means = collections.defaultdict(float)
 memory_means = collections.defaultdict(float)
 for test_name in test_names:
     # calculate the mean
-    time_means[test_name] = np.mean([d['Time'] for d in data if d['Benchmark'] == test_name])
-    memory_means[test_name] = np.mean([d['Memory'] for d in data if d['Benchmark'] == test_name])
+    test_data_time = [d['Time'] for d in data if d['Benchmark'] == test_name]
+    test_data_mem = [d['Memory'] for d in data if d['Benchmark'] == test_name]
+    if test_data_time:
+        time_means[test_name] = sum(test_data_time) / len(test_data_time)
+    if test_data_mem:
+        memory_means[test_name] = sum(test_data_mem) / len(test_data_mem)
 
 # add normalised time and memory to each data point
 for d in data:
-    d['Normalised Time'] = d['Time'] / time_means[d['Benchmark']]
-    d['Normalised Memory'] = d['Memory'] / memory_means[d['Benchmark']]
+    d['Normalised Time'] = d['Time'] / time_means[d['Benchmark']] if time_means[d['Benchmark']] != 0 else 1.0
+    d['Normalised Memory'] = d['Memory'] / memory_means[d['Benchmark']] if memory_means[d['Benchmark']] != 0 else 1.0
 
 # create the graph for time
 fig = px.box(data, x="Benchmark", y="Normalised Time", color="Allocator", log_y=True)

--- a/graphs.py
+++ b/graphs.py
@@ -12,6 +12,15 @@ if len(sys.argv) != 2:
     print('Usage: %s results.txt' % sys.argv[0])
     sys.exit(1)
 
+def parse_time(time_string):
+    parts = time_string.split(':')
+    if len(parts) == 3: # H:MM:SS.ss
+        return int(parts[0]) * 3600 + int(parts[1]) * 60 + float(parts[2])
+    elif len(parts) == 2: # MM:SS.ss
+        return int(parts[0]) * 60 + float(parts[1])
+    else:
+        return float(parts[0])
+
 parse_line = re.compile('^([^ ]+) +([^ ]+) +([0-9:.]+)')
 allocs = collections.defaultdict(lambda: collections.defaultdict(dict))
 
@@ -21,12 +30,7 @@ with open(sys.argv[1]) as f:
         if not match:
             continue
         test_name, alloc_name, time_string = match.groups()
-        time_split = time_string.split(':')
-        time_taken = 0
-        if len(time_split) == 2:
-            time_taken = int(time_split[0]) * 60 + float(time_split[1])
-        else:
-            time_taken = float(time_split[0])
+        time_taken = parse_time(time_string)
         allocs[test_name][alloc_name] = time_taken
 
 for test_name, results in allocs.items():

--- a/scripts/bencher.dev.py
+++ b/scripts/bencher.dev.py
@@ -1,6 +1,5 @@
 # This script converts the benchmark outputs to the format required by bencher.dev.
 # It creates a file for each allocator with the results in JSON format.
-# It requires numpy for statistical calculations.
 # It generates file names of the form bencher.dev.<allocator>.json.
 # Output files will contain the mean, high, and low values for memory and time for each benchmark:
 # {
@@ -33,12 +32,8 @@
 
 import re
 import sys
+import json
 import collections
-try:
-    import numpy as np 
-except ImportError:
-    print('You need to install numpy.')
-    sys.exit(1)
 
 if len(sys.argv) != 2:
     print('Usage: %s benchres.csv' % sys.argv[0])
@@ -48,9 +43,20 @@ if len(sys.argv) != 2:
     print('The script generates a file per allocator for submission to bencher.dev.')
     sys.exit(1)
 
-parse_line = re.compile('^([^ ]+) +([^ ]+) +([0-9:.]+) +([0-9]+) [0-9:.]+ [0-9:.]+ [0-9:.]+ [0-9:.]+$')
+def parse_time(time_string):
+    parts = time_string.split(':')
+    if len(parts) == 3: # H:MM:SS.ss
+        return int(parts[0]) * 3600 + int(parts[1]) * 60 + float(parts[2])
+    elif len(parts) == 2: # MM:SS.ss
+        return int(parts[0]) * 60 + float(parts[1])
+    else:
+        return float(parts[0])
+
+# Match line format: benchmark allocator elapsed rss user sys faults reclaims
+parse_line = re.compile(r'^([^ ]+)\s+([^ ]+)\s+([0-9:.]+)\s+([0-9]+)')
 data = []
 test_names = set()
+alloc_names = set()
 
 # read in the data
 with open(sys.argv[1]) as f:
@@ -59,51 +65,36 @@ with open(sys.argv[1]) as f:
         if not match:
             continue
         test_name, alloc_name, time_string, memory = match.groups()
-        time_split = time_string.split(':')
-        time_taken = 0
+        time_taken = parse_time(time_string)
         test_names.add(test_name)
-        if len(time_split) == 2:
-            time_taken = int(time_split[0]) * 60 + float(time_split[1])
-        else:
-            time_taken = float(time_split[0])
+        alloc_names.add(alloc_name)
         data.append({"Benchmark":test_name, "Allocator":alloc_name, "Time":time_taken, "Memory":int(memory)})
 
-# Output data in json of the form
-#
-# {
-#    "<Benchmark>":{
-#      "memory":{
-#        "value": <memory-mean>
-#        "high-value": <memory-high>
-#        "low-value": <memory-low>
-#      }
-#      "time":{
-#        "value": <time-mean>
-#        "high-value": <time-high>
-#        "low-value": <time-low>
-#      }
-#    }
-# }
-
-import json
-
-for alloc in set(d["Allocator"] for d in data if d["Benchmark"] == test_name):
+for alloc in alloc_names:
     output = {}
     for test_name in test_names:
+        alloc_test_data = [d for d in data if d["Benchmark"] == test_name and d["Allocator"] == alloc]
+        if not alloc_test_data:
+            continue
+
+        mem_vals = [d["Memory"] for d in alloc_test_data]
+        time_vals = [d["Time"] for d in alloc_test_data]
+
         output[test_name] = {
             "memory": {
-                "value": float(np.mean([d["Memory"] for d in data if d["Benchmark"] == test_name])),
-                "high-value": float(np.max([d["Memory"] for d in data if d["Benchmark"] == test_name])),
-                "low-value": float(np.min([d["Memory"] for d in data if d["Benchmark"] == test_name])),
+                "value": sum(mem_vals) / len(mem_vals),
+                "high-value": float(max(mem_vals)),
+                "low-value": float(min(mem_vals)),
             },
             "time": {
-                "value": float(np.mean([d["Time"] for d in data if d["Benchmark"] == test_name])),
-                "high-value": float(np.max([d["Time"] for d in data if d["Benchmark"] == test_name])),
-                "low-value": float(np.min([d["Time"] for d in data if d["Benchmark"] == test_name])),
+                "value": sum(time_vals) / len(time_vals),
+                "high-value": float(max(time_vals)),
+                "low-value": float(min(time_vals)),
             }
         }
-    result = json.dumps(output, indent=2)
-    with open(f"bencher.dev.{alloc}.json", "w") as f:
-        f.write(result)
-    print(f"Output written to bencher.dev.{alloc}.json")
 
+    if output:
+        result = json.dumps(output, indent=2)
+        with open(f"bencher.dev.{alloc}.json", "w") as f:
+            f.write(result)
+        print(f"Output written to bencher.dev.{alloc}.json")


### PR DESCRIPTION
This submission fixes several critical issues in the benchmarking and reporting scripts. 

Key changes include:
1. **Robust Time Parsing**: All data processing scripts (`bencher.dev.py`, `graphs.py`, `graph_many.py`) now correctly handle durations exceeding one hour (H:MM:SS format), which previously caused parsing failures or incorrect results.
2. **Corrected Statistics**: Fixed a major bug in `bencher.dev.py` where statistics were being calculated across the entire dataset instead of being filtered by both benchmark and allocator.
3. **Dependency Reduction**: Removed the `numpy` dependency from `bencher.dev.py` and `graph_many.py`, making the suite easier to run in minimal environments.
4. **Configuration Cleanup**: Fixed typos and duplicates in `bench.sh` to ensure all intended allocator variants are correctly recognized and tested.
5. **Stability**: Improved `graph_many.py` to gracefully handle cases with zero or missing data points.

---
*PR created automatically by Jules for task [16252204947526832697](https://jules.google.com/task/16252204947526832697) started by @tonestone57*